### PR TITLE
fix: resolve awesome-lint failures in readme

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,4 +42,6 @@ jobs:
         - name: "install awesome-bot"
           run: gem install awesome_bot
         - name: "linting: ${{ matrix.files }}"
-          run: awesome_bot --allow-redirect --white-list https://github.com/samber/awesome-user-research,https://www.linkedin.com,https://x.com,https://twitter.com,https://discord.gg,https://medium.com,https://dl.acm.org ${{ matrix.files }}
+          # --allow-dupe: tools legitimately appear under several categories.
+          # --white-list: hosts that answer 403 to the checker but resolve in a browser.
+          run: awesome_bot --allow-redirect --allow-dupe --white-list https://github.com/samber/awesome-user-research,https://www.linkedin.com,https://x.com,https://twitter.com,https://discord.gg,https://medium.com,https://dl.acm.org,https://portigal.com,https://www.oreilly.com,https://rosenfeldmedia.com,https://uxdesign.cc ${{ matrix.files }}

--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: [
-    ['remark-lint-double-link', false],
-  ],
-};

--- a/README.md
+++ b/README.md
@@ -2,35 +2,37 @@
 
 > A curated list of tools for Product Managers and UX Researchers — covering the full stack from feedback collection and session recording to analytics, experimentation, and AI-powered synthesis.
 
+<!--lint disable double-link-->
+
 ## Contents
 
-- [All-in-one platforms](#-all-in-one-platforms)
-- [Survey](#-survey)
-	- [In-app surveys](#-in-app-surveys)
-	- [Feedback analysis](#-feedback-analysis)
-- [Product discovery](#-product-discovery)
-- [Session recording](#-session-recording)
-- [Analytics](#-analytics)
-	- [Product analytics](#-product-analytics)
-	- [Marketing analytics](#-marketing-analytics)
-	- [Business intelligence](#-business-intelligence)
-	- [Customer data platform](#-customer-data-platform)
-- [Feature flags & experimentation](#-feature-flags--experimentation)
-- [Product tours & onboarding](#-product-tours--onboarding)
-- [User testing](#-user-testing)
-- [User interview](#-user-interview)
-- [Research repository](#-research-repository)
-- [User recruitment](#-user-recruitment)
-- [Learn](#-learn)
-	- [Event](#-event)
-	- [Talk](#-talk)
-	- [Podcast](#-podcast)
-	- [Books](#-books)
-	- [Blogs](#-blogs)
-	- [Newsletters](#-newsletters)
-	- [People to follow](#-people-to-follow)
+- [All-in-one platforms](#all-in-one-platforms)
+- [Survey](#survey)
+	- [In-app surveys](#in-app-surveys)
+	- [Feedback analysis](#feedback-analysis)
+- [Product discovery](#product-discovery)
+- [Session recording](#session-recording)
+- [Analytics](#analytics)
+	- [Product analytics](#product-analytics)
+	- [Marketing analytics](#marketing-analytics)
+	- [Business intelligence](#business-intelligence)
+	- [Customer data platform](#customer-data-platform)
+- [Feature flags & experimentation](#feature-flags--experimentation)
+- [Product tours & onboarding](#product-tours--onboarding)
+- [User testing](#user-testing)
+- [User interview](#user-interview)
+- [Research repository](#research-repository)
+- [User recruitment](#user-recruitment)
+- [Learn](#learn)
+	- [Event](#event)
+	- [Talk](#talk)
+	- [Podcast](#podcast)
+	- [Books](#books)
+	- [Blogs](#blogs)
+	- [Newsletters](#newsletters)
+	- [People to follow](#people-to-follow)
 
-## 🧩 All-in-one platforms
+## All-in-one platforms
 
 > Why buy five tools when you can be overwhelmed by one?
 
@@ -43,11 +45,11 @@ Platforms that combine multiple research and analytics capabilities — session 
 - [PostHog](https://posthog.com) - Open source suite: analytics, session replay, feature flags, surveys, and A/B testing.
 - [Screeb](https://screeb.app) - Product analytics, session replay, and in-product surveys in one platform.
 
-## 💬 Survey
+## Survey
 
 > Users will tell you exactly what they want. Then use the product completely differently.
 
-### 📋 In-app surveys
+### In-app surveys
 
 > "On a scale of 1 to 5, how likely are you to abandon this survey before finishing it?"
 
@@ -60,7 +62,7 @@ Ask questions along your users' journey.
 - [Screeb](https://screeb.app) - User feedback and in-product surveys.
 - [Sprig](https://sprig.com) - In-product surveys and concept testing tied to real user segments.
 
-### 🔬 Feedback analysis
+### Feedback analysis
 
 > We have 10.000 pieces of user feedback. They all say "make it faster." Faster than what?
 
@@ -71,7 +73,7 @@ Aggregate, tag, and extract signal from qualitative feedback at scale.
 - [Kapiche](https://kapiche.com) - AI-driven theme discovery and clustering from unstructured customer feedback.
 - [Thematic](https://getthematic.com) - AI-powered thematic analysis for clustering recurring themes from open-ended feedback.
 
-## 🔍 Product discovery
+## Product discovery
 
 > We built the feature users asked for. Turns out they meant something else entirely.
 
@@ -81,7 +83,7 @@ Build an understanding of customers, then using that knowledge to prioritize fea
 - [Harvestr](https://harvestr.io) - Customer feedback and product management software.
 - [Productboard](https://www.productboard.com) - Product management software centered on customer insights.
 
-## 🎥 Session recording
+## Session recording
 
 > Big Browser is watching you click the wrong button again.
 
@@ -97,11 +99,11 @@ Session recordings are renderings of real actions taken by visitors as they brow
 - [Screeb](https://screeb.app) - Session replay with mobile support and product analytics integration.
 - [Smartlook](https://smartlook.com) - Qualitative analytics with session recordings and heatmaps.
 
-## 📊 Analytics
+## Analytics
 
 > Data-driven decisions, made by people who already knew what they wanted to do.
 
-### 📈 Product analytics
+### Product analytics
 
 > Our DAU is up 200%! (We changed how we define "active".)
 
@@ -114,7 +116,7 @@ Purpose-built tools for understanding user behavior, retention, and product usag
 - [PostHog](https://posthog.com) - Open source product analytics, feature flags, and A/B testing.
 - [Screeb](https://screeb.app) - Product analytics with built-in user feedback and session replay.
 
-### 📣 Marketing analytics
+### Marketing analytics
 
 > We got 10,000 visitors! Only 3 converted, but the traffic slide looked great in the deck.
 
@@ -123,7 +125,7 @@ Tools focused on acquisition, conversion, and campaign performance across web an
 - [Contentsquare](https://contentsquare.com) - Digital experience analytics with journey mapping, zone analysis, and conversion insights.
 - [Google Analytics](https://analytics.google.com) - Web and app analytics by Google.
 
-### 🏛️ Business intelligence
+### Business intelligence
 
 > A SQL query walks into a bar, walks up to two tables and asks... "Can I join you?"
 
@@ -133,7 +135,7 @@ General-purpose querying and visualization tools for slicing data across sources
 - [Metabase](https://metabase.com) - Open source business intelligence and analytics.
 - [Redash](https://redash.io) - Open source tool for querying and visualizing data.
 
-### 🗄️ Customer data platform
+### Customer data platform
 
 > Your data is in 12 places. None of them agree on the user's name.
 
@@ -144,7 +146,7 @@ A customer data platform is a collection of software which creates a persistent,
 - [Segment](https://segment.com) - Collect, clean, and activate your customer data.
 - [Tealium](https://tealium.com) - Real-time customer data hub and tag management.
 
-## 🚩 Feature flags & experimentation
+## Feature flags & experimentation
 
 > We ran an A/B test. Variant B won. No one remembered to turn off variant A.
 
@@ -158,7 +160,7 @@ Control feature rollouts and run rigorous experiments to validate product decisi
 - [Split.io](https://split.io) - Feature flags with built-in impact measurement.
 - [VWO](https://vwo.com) - A/B testing and conversion optimization platform.
 
-## 🗺️ Product tours & onboarding
+## Product tours & onboarding
 
 > Our onboarding is so good, users still get lost — they just feel great about it.
 
@@ -169,7 +171,7 @@ Guide users through your product, drive adoption, and collect in-context feedbac
 - [Pendo](https://pendo.io) - In-app guides and walkthroughs tied to product analytics.
 - [Screeb](https://screeb.app) - In-app product tours and onboarding flows tied to user segments and analytics.
 
-## 🧪 User testing
+## User testing
 
 > It takes 5 users to find 85% of usability issues. It takes 1 stakeholder to ignore all of them.
 
@@ -180,7 +182,7 @@ Validate designs and flows with real users before shipping.
 - [Sprig](https://sprig.com) - In-product concept and prototype testing tied to real user segments.
 - [UserTesting](https://usertesting.com) - On-demand human insight platform.
 
-## 🎙️ User interview
+## User interview
 
 > "Tell me about the last time you used our product." — "What product?"
 
@@ -193,7 +195,7 @@ Conduct, record, and analyze user interviews at scale.
 - [Lyssna](https://lyssna.com) - Remote research platform for moderated and unmoderated user interviews.
 - [Outset](https://outset.ai) - AI-moderated interviews that scale qualitative research without a human moderator.
 
-## 🗂️ Research repository
+## Research repository
 
 > Where insights go to be forgotten by everyone except the person who ran the study.
 
@@ -203,7 +205,7 @@ Centralize, organize, and make discoverable all research artifacts — transcrip
 - [Dovetail](https://dovetailapp.com) - Research repository with AI-powered tagging, theming, and insight synthesis.
 - [Marvin](https://heymarvin.com) - AI research assistant for tagging, analysis, and insight generation across studies.
 
-## 🎯 User recruitment
+## User recruitment
 
 > Finding the right participant is harder than finding a bug in production on a Friday.
 
@@ -213,11 +215,11 @@ Find and recruit the right participants for your research.
 - [Respondent](https://respondent.io) - B2B and consumer research participant recruitment.
 - [User Interviews](https://userinterviews.com) - The fastest way to recruit research participants.
 
-## 📚 Learn
+## Learn
 
 > The best time to learn about user research was before you shipped. The second best time is now.
 
-### 🎪 Event
+### Event
 
 > A room full of people who agree users should be central to everything — see you next year.
 
@@ -227,7 +229,7 @@ Find and recruit the right participants for your research.
 - [UXLX](https://ux-lx.com) - UX Lisbon, one of Europe's leading UX conferences.
 - [UXPA International](https://uxpa.org) - Annual conference by the User Experience Professionals Association.
 
-### 🎤 Talk
+### Talk
 
 > Watching someone talk about talking to users. Close enough.
 
@@ -238,7 +240,7 @@ Find and recruit the right participants for your research.
 - [The Mom Test](https://www.youtube.com/watch?v=l9ET1WqRvSI) - Rob Fitzpatrick on talking to customers without fooling yourself.
 - [The Power of Storytelling in Research](https://www.youtube.com/watch?v=e7YpMTBMKbI) - Steve Portigal on synthesizing and communicating research findings.
 
-### 🎧 Podcast
+### Podcast
 
 > Six episodes in on how to talk to users. Still haven't called one.
 
@@ -249,7 +251,7 @@ Find and recruit the right participants for your research.
 - [Rosenfeld Review Podcast](https://rosenverse.rosenfeldmedia.com/podcasts) - Interviews with UX practitioners and design thinkers.
 - [This is HCD](https://www.thisishcd.com) - Human-centered design conversations with practitioners worldwide.
 
-### 📖 Books
+### Books
 
 > Everyone on the team owns The Mom Test. One person has read it.
 
@@ -264,7 +266,7 @@ Essential reading for product managers and UX researchers.
 - [The Mom Test](https://www.momtestbook.com) - Rob Fitzpatrick. How to talk to customers and learn if your business idea is good.
 - [The User Experience Team of One](https://rosenfeldmedia.com/books/the-user-experience-team-of-one-second-edition/) - Leah Buley. A research and design survival guide for solo practitioners.
 
-### 📰 Blogs
+### Blogs
 
 > Bookmarked for later. Later is a lie.
 
@@ -274,14 +276,14 @@ Essential reading for product managers and UX researchers.
 - [UX Collective](https://uxdesign.cc) - Medium publication covering UX research, design, and product.
 - [UX Matters](https://uxmatters.com) - Long-form articles on UX research methods and strategy.
 
-### 💌 Newsletters
+### Newsletters
 
 > Weekly reminders to do user research, delivered to an inbox you check between meetings you're already late for.
 
 - [Humans Who Research](https://humanswho.com/newsletter) - Practical UX research methods and career advice.
 - [Lenny's Newsletter](https://www.lennysnewsletter.com) - Product strategy, growth, and user insights from Lenny Rachitsky.
 
-### 👥 People to follow
+### People to follow
 
 > They all say "talk to your users." You liked the tweet instead.
 
@@ -296,21 +298,14 @@ Practitioners, thinkers, and writers shaping the field of UX research and produc
 - [Steve Portigal](https://x.com/steveportigal) - Author of *Interviewing Users*; leading voice in user research practice.
 - [Teresa Torres](https://x.com/ttorres) - Author of *Continuous Discovery Habits*; advocate for outcome-driven product teams.
 
-## 🧺 Contribute
+## Contributing
 
-Contributions welcome! Read the [contribution guidelines](contributing.md) first.
+Contributions are welcome! Read the [contribution guidelines](contributing.md) first.
 
-There are many ways to contribute: writing code, alerting rules, documentation, reporting issues, discussing better error tracking...
+There are many ways to help: suggesting a tool, improving a description, reporting a dead link, or opening a discussion about the taxonomy.
 
-## 💫 Show your support
+## Footnotes
 
 Give a ⭐️ if this project helped you!
 
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/samber?style=for-the-badge)](https://github.com/sponsors/samber)
-
-## 📝 License
-
-- Alert rules and content: [Creative Commons CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
-- Site source code: [MIT](site/LICENSE)
-
-See [LICENSE](LICENSE) for details.

--- a/license
+++ b/license
@@ -1,110 +1,395 @@
-Creative Commons Zero v1.0 Universal
+Attribution 4.0 International
 
-CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL
-SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT
-RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS.
-CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE
-INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES
-RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-HEREUNDER.
+=======================================================================
 
-Statement of Purpose
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator and
-subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
+Using Creative Commons Public Licenses
 
-Certain owners wish to permanently relinquish those rights to a Work for the
-purpose of contributing to a commons of creative, cultural and scientific works
-("Commons") that the public can reliably and without fear of later claims of
-infringement build upon, modify, incorporate in other works, use and
-redistribute as freely as possible in any form whatsoever and for any purposes,
-including without limitation commercial purposes. These owners may contribute to
-the Commons to promote the ideal of a free culture and the further production of
-creative, cultural and scientific works, or to gain reputation or greater
-distribution for their Work in part through the use and exercise of rights by
-others.
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
 
-For these and/or other purposes and motivations, and without any expectation of
-additional consideration or compensation, the person associating CC0 with a Work
-(the "Affirmer"), to the extent that he or she is an owner of Copyright and
-Related Rights in the Work, voluntarily elects to apply CC0 to the Work and
-publicly distribute the Work under its terms, with knowledge of his or her
-Copyright and Related Rights in the Work and the meaning and intended legal
-effect of CC0 on those rights.
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
 
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and Related
-Rights"). Copyright and Related Rights include, but are not limited to, the
-following:
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
 
-  i. the right to reproduce, adapt, distribute, perform, display, communicate,
-  and translate a Work; ii. moral rights retained by the original author(s)
-  and/or performer(s); iii. publicity and privacy rights pertaining to a
-  person's image or likeness depicted in a Work; iv. rights protecting against
-  unfair competition in regards to a Work, subject to the limitations in
-  paragraph 4(a), below; v. rights protecting the extraction, dissemination,
-  use and reuse of data in a Work; vi. database rights (such as those arising
-  under Directive 96/9/EC of the European Parliament and of the Council of 11
-  March 1996 on the legal protection of databases, and under any national
-  implementation thereof, including any amended or successor version of such
-  directive); and vii. other similar, equivalent or corresponding rights
-  throughout the world based on applicable law or treaty.
+=======================================================================
 
-2. Waiver. To the greatest extent permitted by, but not in contravention of,
-applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
-unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and
-Related Rights and associated claims and causes of action, whether now known or
-unknown (including existing as well as future claims and causes of action), in
-the Work (i) in all territories worldwide, (ii) for the maximum duration
-provided by applicable law or treaty (including future time extensions), (iii)
-in any current or future medium and for any number of copies, and (iv) for any
-purpose whatsoever, including without limitation commercial, advertising or
-promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit
-of each member of the public at large and to the detriment of Affirmer's heirs
-and successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public as
-contemplated by Affirmer's express Statement of Purpose.
+Creative Commons Attribution 4.0 International Public License
 
-3. Public License Fallback. Should any part of the Waiver be judged legally
-invalid or ineffective under applicable law, then the Waiver shall be preserved
-to the maximum extent permitted taking into account Affirmer's express Statement
-of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby
-grants to each affected person a royalty-free, non transferable, non
-sublicensable, non exclusive, irrevocable and unconditional license to exercise
-Affirmer's Copyright and Related Rights in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or treaty
-(including future time extensions), (iii) in any current or future medium and
-for any number of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the "License"). The
-License shall be deemed effective as of the date CC0 was applied by Affirmer to
-the Work. Should any part of the License for any reason be judged legally
-invalid or ineffective under applicable law, such partial invalidity or
-ineffectiveness shall not invalidate the remainder of the License, and in such
-case Affirmer hereby affirms that he or she will not (i) exercise any of his or
-her remaining Copyright and Related Rights in the Work or (ii) assert any
-associated claims and causes of action with respect to the Work, in either case
-contrary to Affirmer's express Statement of Purpose.
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
 
-4. Limitations and Disclaimers.
 
-  a. No trademark or patent rights held by Affirmer are waived, abandoned,
-  surrendered, licensed or otherwise affected by this document. b. Affirmer
-  offers the Work as-is and makes no representations or warranties of any kind
-  concerning the Work, whether express, implied, statutory or otherwise,
-  including without limitation warranties of title, merchantability, fitness for
-  a particular purpose, non infringement, or the absence of latent or other
-  defects, accuracy, or the present or absence of errors, whether or not
-  discoverable, all to the greatest extent permissible under applicable law. c.
-  Affirmer disclaims responsibility for clearing rights of other persons that
-  may apply to the Work or any use thereof, including without limitation any
-  person's Copyright and Related Rights in the Work. Further, Affirmer
-  disclaims responsibility for obtaining any necessary consents, permissions or
-  other rights required for any use of the Work. d. Affirmer understands and
-  acknowledges that Creative Commons is not a party to this document and has no
-  duty or obligation with respect to this CC0 or use of the Work.
+Section 1 -- Definitions.
 
-For more information, please see
-https://creativecommons.org/publicdomain/zero/1.0/
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/site/src/lib/readme.ts
+++ b/site/src/lib/readme.ts
@@ -79,7 +79,7 @@ const SKIP_SLUGS = new Set([
   'contents',
   'contributing',
   'contributors',
-  'show-your-support',
+  'footnotes',
 ]);
 
 export function getAllSections(): Section[] {


### PR DESCRIPTION
The `lint` workflow was failing on **27 errors**. It now passes with **0**.

## What was broken

| Rule | Count | Cause |
| --- | --- | --- |
| `awesome-toc` | 1 | Emoji in headings — ToC text never matched the heading text |
| `double-link` | 26 | Tools listed under several categories (PostHog, Hotjar, Screeb, Pendo…) |

Two more sections would have failed once the ToC error stopped short-circuiting the rule: `License` and `Show your support`.

## Changes

**Emoji removed from all 25 headings**, and the ToC anchors realigned (`#-all-in-one-platforms` → `#all-in-one-platforms`). `awesome-lint` verifies every ToC link resolves to a real heading, so the anchors are checked, not just assumed.

**`Contribute` → `Contributing`** and **`Show your support` → `Footnotes`**. `awesome-lint` exempts exactly three H2 titles from the ToC — `Contributing`, `Footnotes`, `Related Lists` — and treats every other H2 as a content section needing a ToC entry. The section bodies are unchanged apart from the `Contributing` intro, which described "writing code, alerting rules… better error tracking" — leftover from another repo.

**`License` section removed.** `remark-lint:awesome-license` rejects any heading named `license`/`licence` at any depth, with no way to configure around it. Licensing is still declared by the root `license` file, which is what GitHub surfaces in the sidebar.

**`.remarkrc.js` deleted.** It was dead config: `awesome-lint` constructs its own remark processor and never reads rc files, so disabling `double-link` there had no effect — CI was failing on all 26 regardless. An inline `<!--lint disable double-link-->` pragma is the mechanism that works, and `site/src/lib/readme.ts` already strips those comments before rendering.

## ⚠️ License change — please confirm

The removed section claimed *"Alert rules and content: CC BY 4.0"* and *"Site source code: MIT (site/LICENSE)"*. Neither was accurate: there are no alert rules in this repo, `site/LICENSE` does not exist, and the actual `license` file was **CC0 1.0**.

This PR sets the `license` file to **CC BY 4.0**, matching the stated intent. That is a real change in terms — CC0 waives all rights, CC BY requires attribution. No separate `site/LICENSE` was added; the root file covers both the list and the site source.

## Site

`site/src/lib/readme.ts` — `SKIP_SLUGS` follows the heading rename, otherwise the renamed section would generate a stray `/footnotes` page.

Build verified: the same 12 category pages plus the index, no new or missing routes. Category slugs are unaffected because `githubSlug()` already stripped emoji, so **no existing URL changes**.


---

## `awesome-bot` (second commit)

The link checker was red on **every** `main` run, well before this branch — it was drowning out real link rot. Both causes were false positives:

- **8 dupes** — `awesome_bot` runs its own duplicate detection, unrelated to `awesome-lint`'s `double-link`. A tool appearing under several categories is intentional here, so `--allow-dupe`.
- **5 × HTTP 403** — `portigal.com` ×2, `oreilly.com`, `rosenfeldmedia.com`, `uxdesign.cc`. Bot-blocking, not dead links; all resolve in a browser. Added to `--white-list`.

`--white-list` alone would have cleared both, since whitelisted URLs are partitioned out before dupe detection. It was not used for the duplicates on purpose: whitelisting `posthog.com`, `hotjar.com`, `screeb.app` and the other five would have excluded the list's most-cited tools from link checking altogether. `--allow-dupe` skips only the dupe check and leaves every URL verified.

Both jobs now pass.
