### PR TITLE
feat(site): prepare google search console verification

### DIFF
--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://samber.github.io/awesome-user-research/</loc>
-    <lastmod>2026-04-22</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -1,0 +1,18 @@
+---
+// GA4 property for the public site. Doubles as the Google Search Console ownership
+// proof: the "Google Analytics" verification method only accepts the gtag.js snippet
+// when it renders inside <head>, so this component must be placed there on every page.
+const GA_MEASUREMENT_ID = 'G-N4SYF5LHT5';
+---
+
+<!-- Google tag (gtag.js) -->
+<script async is:inline src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+></script>
+<script is:inline define:vars={{ GA_MEASUREMENT_ID }}>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+  gtag('config', GA_MEASUREMENT_ID);
+</script>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
+import Analytics from '../components/Analytics.astro';
 
 const SITE_URL = 'https://samber.github.io/awesome-user-research/';
 
@@ -145,6 +146,8 @@ const jsonLd = {
 
     <!-- Structured Data -->
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+
+    <Analytics />
   </head>
   <body>
     <div class="hero">
@@ -188,16 +191,5 @@ const jsonLd = {
     </div>
 
     <slot />
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-N4SYF5LHT5"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-N4SYF5LHT5');
-</script>
-
   </body>
 </html>

--- a/site/src/pages/[category].astro
+++ b/site/src/pages/[category].astro
@@ -1,5 +1,6 @@
 ---
 import { getAllSections } from '../lib/readme';
+import Analytics from '../components/Analytics.astro';
 import '../styles/global.css';
 
 export function getStaticPaths() {
@@ -131,6 +132,8 @@ const jsonLd = {
 
     <!-- Structured Data -->
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+
+    <Analytics />
   </head>
   <body>
     <div class="hero" style="padding: 2.5rem 1rem;">


### PR DESCRIPTION
Sets up the site so a Google Search Console URL-prefix property on `https://samber.github.io/awesome-user-research/` can be verified with the **Google Analytics** method.

## Why

That method only accepts the `gtag.js` snippet when it renders inside `<head>`. The tag sat at the bottom of `<body>`, and category pages carried no GA tag at all — so verification would fail and category traffic was never tracked.

## Changes

- Extract the GA4 tag into `site/src/components/Analytics.astro`, mounted in the `<head>` of both the base layout and the category pages.
- Delete `site/public/sitemap.xml`. It shadowed the dynamic `sitemap.xml.ts` route and advertised a single URL; the route emits all 13 pages.

## Follow-up (outside this PR)

Once merged and deployed: create the URL-prefix property, verify via Google Analytics, and submit `https://samber.github.io/awesome-user-research/sitemap.xml`.