### PR TITLE
chore(site): move posthog ingestion to hogpost3 proxy

### DIFF
--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -30,7 +30,7 @@
     // so an http host would be blocked as mixed content and drop every event.
     // ui_host stays on the real app because the proxy only fronts ingestion,
     // and toolbar and session-replay links must resolve.
-    api_host: 'https://hogpost2.samber.dev',
+    api_host: 'https://hogpost3.samber.dev',
     ui_host: 'https://us.posthog.com',
     defaults: '2026-05-30',
     // Nobody ever logs in to an awesome list, so 'identified_only' — the default

--- a/site/src/components/Analytics.astro
+++ b/site/src/components/Analytics.astro
@@ -24,11 +24,13 @@
 <script is:inline>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}p||((p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",p.onerror=function(){p=null},(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r));var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="al ol ll init Il Rl Tl Ml Ol za El Dl Sl capture getExtension Pl nl Hl calculateEventProperties Bl register register_once register_for_session unregister unregister_for_session Vl Cl zl getFeatureFlag getFeatureFlagPayload getFeatureFlagResult getAllFeatureFlags isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Gl identify setPersonProperties unsetPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset Zl shutdown setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Ul ql createPersonProfile setInternalOrTestUser Wl ul hl opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $l debug Ua Jn getPageViewId captureTraceFeedback captureTraceMetric bl".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
   posthog.init('phc_kWYTj2Qkdo6xE2P2Pc68ZuF86TTVw9AuyQPBCL5JJKL3', {
-    // Ingest through the shared reverse proxy rather than *.i.posthog.com, which
-    // ad blockers drop by domain — pointing at PostHog directly silently loses a
-    // large share of the traffic. ui_host stays on the real app because the proxy
-    // only fronts ingestion, and toolbar and session-replay links must resolve.
-    api_host: 'https://hogpost.samber.dev',
+    // Ingest through the reverse proxy rather than *.i.posthog.com, which ad
+    // blockers drop by domain — pointing at PostHog directly silently loses a
+    // large share of the traffic. Must stay https: the site is served over TLS,
+    // so an http host would be blocked as mixed content and drop every event.
+    // ui_host stays on the real app because the proxy only fronts ingestion,
+    // and toolbar and session-replay links must resolve.
+    api_host: 'https://hogpost2.samber.dev',
     ui_host: 'https://us.posthog.com',
     defaults: '2026-05-30',
     // Nobody ever logs in to an awesome list, so 'identified_only' — the default


### PR DESCRIPTION
Points PostHog ingestion at `hogpost3.samber.dev`.

## Why this host

`hogpost3` is the managed reverse proxy registered under **samber-oss2**, the organization that owns this project. `hogpost` and `hogpost2` belong to `samber-oss1`.

## Verification

The proxy was still **Issuing** when this branch was pushed and returned Cloudflare error 1014 (`CNAME cross-user banned`). Provisioning has since completed:

| Check | Result |
|---|---|
| `GET /static/array.js` ×3 | **200** |
| `GET /array/phc_…/config.js` | **200** |
| DNS | `…cf-prod-us-proxy.proxyhog.com` — us region, matching the project |

Safe to merge.

## On the scheme

Wired as `https://`. The site is served over TLS, so an `http` ingestion host would be blocked as mixed content and silently drop every event.