### PR TITLE
docs: cross-link sibling awesome lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 See also:
 
 - [awesome-ai-native](https://github.com/samber/awesome-ai-native) - Products where the LLM is the product itself.
+- [awesome-olap](https://github.com/samber/awesome-olap) - OLAP databases, data lakes and data engineering tools.
 - [awesome-prometheus-alerts](https://github.com/samber/awesome-prometheus-alerts) - Collection of Prometheus alerting rules.
 
 ## Contents

--- a/site/src/components/SiteFooter.astro
+++ b/site/src/components/SiteFooter.astro
@@ -1,0 +1,66 @@
+---
+// Cross-links to the sibling awesome lists maintained in the same GitHub organisation.
+// Deliberately one quiet line: these are neighbouring projects, not navigation for this list.
+const SIBLINGS = [
+  { name: 'Awesome AI-Native', url: 'https://samber.github.io/awesome-ai-native/' },
+  { name: 'Awesome OLAP', url: 'https://samber.github.io/awesome-olap/' },
+  { name: 'Awesome Prometheus Alerts', url: 'https://samber.github.io/awesome-prometheus-alerts/' },
+];
+---
+
+<footer class="site-footer">
+  <div class="site-footer-inner">
+    <span class="site-footer-label">More awesome lists</span>
+    <ul class="site-footer-links">
+      {SIBLINGS.map(({ name, url }) => (
+        <li><a href={url}>{name}</a></li>
+      ))}
+    </ul>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    border-top: 1px solid var(--border);
+    background: var(--bg-alt);
+    padding: 1.5rem 1rem;
+    margin-top: 3rem;
+  }
+  .site-footer-inner {
+    max-width: 860px;
+    margin: 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+  }
+  .site-footer-label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    font-size: 0.6875rem;
+  }
+  .site-footer-links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+  }
+  .site-footer-links li + li::before {
+    content: '·';
+    margin-right: 0.5rem;
+    color: var(--border);
+  }
+  .site-footer-links a {
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+  .site-footer-links a:hover {
+    color: var(--link);
+    text-decoration: underline;
+  }
+</style>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { readFileSync } from 'node:fs';
 import Analytics from '../components/Analytics.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 
 const SITE_URL = 'https://samber.github.io/awesome-user-research/';
 
@@ -191,5 +192,7 @@ const jsonLd = {
     </div>
 
     <slot />
+
+    <SiteFooter />
   </body>
 </html>

--- a/site/src/pages/[category].astro
+++ b/site/src/pages/[category].astro
@@ -1,6 +1,7 @@
 ---
 import { getAllSections } from '../lib/readme';
 import Analytics from '../components/Analytics.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import '../styles/global.css';
 
 export function getStaticPaths() {
@@ -158,6 +159,8 @@ const jsonLd = {
     <main class="content">
       <Fragment set:html={html} />
     </main>
+
+    <SiteFooter />
   </body>
 </html>
 


### PR DESCRIPTION
## Description

The four awesome lists share an audience but had no path between them: a reader landing on one had no way to discover the other three. This adds a discreet cross-reference in the two places a reader looks.

**Website** — new `SiteFooter` component rendering a single quiet line, verified present on all 13 built pages. It is wired into both entry points: `layouts/Base.astro` (homepage) and `pages/[category].astro`, which builds its own HTML document rather than consuming the layout.

> MORE AWESOME LISTS &nbsp; Awesome AI-Native · Awesome OLAP · Awesome Prometheus Alerts

Footer links point at the sibling **sites**, so internal linking stays on `samber.github.io`. README links point at the **repositories**.

**README** — the existing `See also:` block was missing `awesome-olap`; it now lists all three siblings in alphabetical order.

Verified with `npm run build` (13/13 pages carry the footer). `awesome-lint` could not be run to completion in the sandbox: its `awesome-github` rule needs GitHub API access and short-circuits the remaining rules, on this branch and on `main` alike.

## Checklist

Not applicable — no list entries were added or changed.

## New tool submission

Not applicable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128P7a2QABz8fjhn8Bjojb2

---
_Generated by [Claude Code](https://claude.ai/code/session_0128P7a2QABz8fjhn8Bjojb2)_